### PR TITLE
Refactor exception handling related code so that codeSize < 325 can be inlined.

### DIFF
--- a/src/java.base/share/classes/java/lang/Integer.java
+++ b/src/java.base/share/classes/java/lang/Integer.java
@@ -551,13 +551,11 @@ public final class Integer extends Number
         }
 
         if (radix < Character.MIN_RADIX) {
-            throw new NumberFormatException(String.format(
-                "radix %s less than Character.MIN_RADIX", radix));
+            throw NumberFormatException.forMinRadix(radix);
         }
 
         if (radix > Character.MAX_RADIX) {
-            throw new NumberFormatException(String.format(
-                "radix %s greater than Character.MAX_RADIX", radix));
+            throw NumberFormatException.forMaxRadix(radix);
         }
 
         int len = s.length();
@@ -621,13 +619,11 @@ public final class Integer extends Number
         Objects.checkFromToIndex(beginIndex, endIndex, s.length());
 
         if (radix < Character.MIN_RADIX) {
-            throw new NumberFormatException(String.format(
-                "radix %s less than Character.MIN_RADIX", radix));
+            throw NumberFormatException.forMinRadix(radix);
         }
 
         if (radix > Character.MAX_RADIX) {
-            throw new NumberFormatException(String.format(
-                "radix %s greater than Character.MAX_RADIX", radix));
+            throw NumberFormatException.forMaxRadix(radix);
         }
 
         /*
@@ -735,13 +731,11 @@ public final class Integer extends Number
         }
 
         if (radix < Character.MIN_RADIX) {
-            throw new NumberFormatException(String.format(
-                "radix %s less than Character.MIN_RADIX", radix));
+            throw NumberFormatException.forMinRadix(radix);
         }
 
         if (radix > Character.MAX_RADIX) {
-            throw new NumberFormatException(String.format(
-                "radix %s greater than Character.MAX_RADIX", radix));
+            throw NumberFormatException.forMaxRadix(radix);
         }
 
         int len = s.length();
@@ -751,8 +745,7 @@ public final class Integer extends Number
         int i = 0;
         char firstChar = s.charAt(i++);
         if (firstChar == '-') {
-            throw new NumberFormatException(String.format(
-                "Illegal leading minus sign on unsigned string %s.", s));
+            throw NumberFormatException.forUnsign(s);
         }
         int digit = ~0xFF;
         if (firstChar != '+') {
@@ -775,8 +768,7 @@ public final class Integer extends Number
         if (digit < 0) {
             throw NumberFormatException.forInputString(s, radix);
         }
-        throw new NumberFormatException(String.format(
-            "String value %s exceeds range of unsigned int.", s));
+        throw NumberFormatException.forUnsignInt(s);
     }
 
     /**
@@ -812,13 +804,11 @@ public final class Integer extends Number
         Objects.checkFromToIndex(beginIndex, endIndex, s.length());
 
         if (radix < Character.MIN_RADIX) {
-            throw new NumberFormatException(String.format(
-                "radix %s less than Character.MIN_RADIX", radix));
+            throw NumberFormatException.forMinRadix(radix);
         }
 
         if (radix > Character.MAX_RADIX) {
-            throw new NumberFormatException(String.format(
-                "radix %s greater than Character.MAX_RADIX", radix));
+            throw NumberFormatException.forMaxRadix(radix);
         }
 
         /*
@@ -833,8 +823,7 @@ public final class Integer extends Number
         int i = beginIndex;
         char firstChar = s.charAt(i++);
         if (firstChar == '-') {
-            throw new NumberFormatException(
-                "Illegal leading minus sign on unsigned string " + s + ".");
+            throw NumberFormatException.forUnsign(s);
         }
         int digit = ~0xFF;
         if (firstChar != '+') {
@@ -858,8 +847,8 @@ public final class Integer extends Number
             throw NumberFormatException.forCharSequence(s, beginIndex,
                 endIndex, i - (digit < -1 ? 0 : 1));
         }
-        throw new NumberFormatException(String.format(
-            "String value %s exceeds range of unsigned int.", s));
+
+        throw NumberFormatException.forUnsignInt(s);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/Long.java
+++ b/src/java.base/share/classes/java/lang/Long.java
@@ -581,13 +581,11 @@ public final class Long extends Number
         }
 
         if (radix < Character.MIN_RADIX) {
-            throw new NumberFormatException(String.format(
-                "radix %s less than Character.MIN_RADIX", radix));
+            throw NumberFormatException.forMinRadix(radix);
         }
 
         if (radix > Character.MAX_RADIX) {
-            throw new NumberFormatException(String.format(
-                "radix %s greater than Character.MAX_RADIX", radix));
+            throw NumberFormatException.forMaxRadix(radix);
         }
 
         int len = s.length();
@@ -651,13 +649,11 @@ public final class Long extends Number
         Objects.checkFromToIndex(beginIndex, endIndex, s.length());
 
         if (radix < Character.MIN_RADIX) {
-            throw new NumberFormatException(String.format(
-                "radix %s less than Character.MIN_RADIX", radix));
+            throw NumberFormatException.forMinRadix(radix);
         }
 
         if (radix > Character.MAX_RADIX) {
-            throw new NumberFormatException(String.format(
-                "radix %s greater than Character.MAX_RADIX", radix));
+            throw NumberFormatException.forMaxRadix(radix);
         }
 
         /*
@@ -772,13 +768,11 @@ public final class Long extends Number
         }
 
         if (radix < Character.MIN_RADIX) {
-            throw new NumberFormatException(String.format(
-                "radix %s less than Character.MIN_RADIX", radix));
+            throw NumberFormatException.forMinRadix(radix);
         }
 
         if (radix > Character.MAX_RADIX) {
-            throw new NumberFormatException(String.format(
-                "radix %s greater than Character.MAX_RADIX", radix));
+            throw NumberFormatException.forMaxRadix(radix);
         }
 
         int len = s.length();
@@ -788,8 +782,7 @@ public final class Long extends Number
         int i = 0;
         char firstChar = s.charAt(i++);
         if (firstChar == '-') {
-            throw new NumberFormatException(String.format(
-                "Illegal leading minus sign on unsigned string %s.", s));
+            throw NumberFormatException.forUnsign(s);
         }
         int digit = ~0xFF;
         if (firstChar != '+') {
@@ -812,8 +805,7 @@ public final class Long extends Number
         if (digit < 0) {
             throw NumberFormatException.forInputString(s, radix);
         }
-        throw new NumberFormatException(String.format(
-            "String value %s exceeds range of unsigned long.", s));
+        throw NumberFormatException.forUnsignLong(s);
     }
 
     /**
@@ -849,13 +841,11 @@ public final class Long extends Number
         Objects.checkFromToIndex(beginIndex, endIndex, s.length());
 
         if (radix < Character.MIN_RADIX) {
-            throw new NumberFormatException(String.format(
-                "radix %s less than Character.MIN_RADIX", radix));
+            throw NumberFormatException.forMinRadix(radix);
         }
 
         if (radix > Character.MAX_RADIX) {
-            throw new NumberFormatException(String.format(
-                "radix %s greater than Character.MAX_RADIX", radix));
+            throw NumberFormatException.forMaxRadix(radix);
         }
 
         /*
@@ -870,8 +860,7 @@ public final class Long extends Number
         int i = beginIndex;
         char firstChar = s.charAt(i++);
         if (firstChar == '-') {
-            throw new NumberFormatException(
-                "Illegal leading minus sign on unsigned string " + s + ".");
+            throw NumberFormatException.forUnsign(s);
         }
         int digit = ~0xFF;
         if (firstChar != '+') {
@@ -895,8 +884,7 @@ public final class Long extends Number
             throw NumberFormatException.forCharSequence(s, beginIndex,
                 endIndex, i - (digit < -1 ? 0 : 1));
         }
-        throw new NumberFormatException(String.format(
-            "String value %s exceeds range of unsigned long.", s));
+        throw NumberFormatException.forUnsignLong(s);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/NumberFormatException.java
+++ b/src/java.base/share/classes/java/lang/NumberFormatException.java
@@ -82,4 +82,28 @@ public class NumberFormatException extends IllegalArgumentException {
                 + (errorIndex - beginIndex) + " in: \""
                 + s.subSequence(beginIndex, endIndex) + "\"");
     }
+
+    static NumberFormatException forUnsign(CharSequence s) {
+        return new NumberFormatException("Illegal leading minus sign on unsigned string " + s + ".");
+    }
+
+    static NumberFormatException forUnsignLong(CharSequence s) {
+        return new NumberFormatException(String.format(
+                "String value %s exceeds range of unsigned long.", s));
+    }
+
+    static NumberFormatException forUnsignInt(CharSequence s) {
+        return new NumberFormatException(String.format(
+                "String value %s exceeds range of unsigned int.", s));
+    }
+
+    static NumberFormatException forMinRadix(int radix) {
+        return new NumberFormatException(String.format(
+                "radix %s greater than Character.MIN_RADIX", radix));
+    }
+
+    static NumberFormatException forMaxRadix(int radix) {
+        return new NumberFormatException(String.format(
+                "radix %s greater than Character.MAX_RADIX", radix));
+    }
 }


### PR DESCRIPTION
codeSize 350 bytes -> 269 bytes
public static int parseUnsignedInt(CharSequence s, int beginIndex, int endIndex, int radix)

codeSize 327 bytes -> 289 bytes
public static long parseLong(CharSequence s, int beginIndex, int endIndex, int radix)

codeSize 362 bytes -> 281 bytes
public static long parseUnsignedLong(CharSequence s, int beginIndex, int endIndex, int radix)